### PR TITLE
Use -j instead of --jobs to work with Debian Jessie

### DIFF
--- a/builder.bash
+++ b/builder.bash
@@ -40,7 +40,7 @@ EOF
 
 # devbuilder configuration file
 cat <<EOF > $HOME/.devscripts
-DEBUILD_DPKG_BUILDPACKAGE_OPTS="-us -uc -i -b --jobs=$CORES"
+DEBUILD_DPKG_BUILDPACKAGE_OPTS="-us -uc -i -b -j$CORES"
 EOF
 }
 


### PR DESCRIPTION
Note there must be no space between -j and the number of jobs.